### PR TITLE
add support for esm

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,12 @@ if (fs.existsSync(nowConfPath)) {
       } else if (builder && builder.use === '@now/node') {
         console.log(logMessage.join('\n'));
         req.url = dest + (getParams ? '?' + getParams : '');
-        require(handlerFilepath)(req, res);
+        
+        // works for NODE_OPTIONS='-r esm'
+        const objOrModule = require(handlerFilepath)
+        const obj = objOrModule.default ? objOrModule.default : obj
+        obj(req, res)
+        
         delete require.cache[require.resolve(handlerFilepath)];
       } else if (fs.existsSync(handlerFilepath)) {
         console.log(logMessage.join('\n'));


### PR DESCRIPTION
```sh
# assuming we start the script with esm module loader
NODE_OPTIONS='-r esm' now-lambda
```

both versions should now work:
```js
module.exports = (req, res) => {
  res.end("hello world")
}
```

```js
export default (req, res) => {
  res.end("hello world")
}
```