### PR TITLE
use http res.statusCode and res.end

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,8 @@ if (fs.existsSync(nowConfPath)) {
         console.log(logMessage.join('\n'));
         sendFile(res, handlerFilepath);
       } else {
-        res.status(404);
-        res.send(handlerFilepath + ' can not be found.');
+        res.statusCode = 404;
+        res.end(handlerFilepath + ' can not be found.');
       }
     };
 


### PR DESCRIPTION
I think parts were left over from the migration of express to http.  Some express-y API calls were left over in the codebase that doesn't work with the http module alone.