### PR TITLE
Handle Now's distDir config against static build

### DIFF
--- a/example/build/generated.html
+++ b/example/build/generated.html
@@ -1,0 +1,1 @@
+<p>generated</p>

--- a/example/now.json
+++ b/example/now.json
@@ -6,7 +6,8 @@
     { "src": "static/*.*", "use": "@now/static" },
     { "src": "api/*.js", "use": "@now/node" },
     { "src": "*.js", "use": "@now/node" },
-    { "src": "*.html", "use": "@now/static" }
+    { "src": "*.html", "use": "@now/static" },
+    { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "build" } }
   ],
   "routes": [
     { "src": "/api/login", "dest": "/api/login.js"},
@@ -16,6 +17,7 @@
     { "src": "/e/resources/(?<resource>[^/]*)", "dest": "/static/resources/$resource"},
     { "src": "/e/(.*)?", "dest": "/editor.js?id=$1"},
     { "src": "/docs", "dest": "/docs.html"},
+    { "src": "/webapp/(.*)", "dest": "/build/$1"},
     { "src": "/(.*)", "dest": "/index.html"}
   ]
 }

--- a/example/run
+++ b/example/run
@@ -5,5 +5,6 @@
 # curl -i http://localhost:8004/static/sw.js
 # curl -i http://localhost:8004/e/resources/editor.js
 # curl -i http://localhost:8004/docs
+# curl -i http://localhost:8004/webapp/generated.html
 # curl -i http://localhost:8004
 curl -i http://localhost:8004/not-found


### PR DESCRIPTION
I've noticed that the script doesn't support Now's static build configuration called distDir. I've had to add a bit bigger matcher as seen in the changes.